### PR TITLE
add DeepMET producer in 102x

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ scram b -j 10
 cd PhysicsTools/NanoMET/test
 ```
 
+### Add the DeepMET producer to Nano
+Add the DeepMET producer and Nano production chain by
+```
+cd $CMSSW_BASE/src
+git cms-merge-topic yongbinfeng:NanoDeepMETIntegration_102X
+```
+Update the `cmsswdata` to update the `RecoMET` directory by
+```
+patch $CMSSW_BASE/config/toolbox/slc7_amd64_gcc700/tools/selected/cmsswdata.xml < PhysicsTools/NanoMET/cmsswdata.patch
+```
+Compile and go to the test directory
+```
+scram b -j 10
+cd PhysicsTools/NanoMET/test
+```
+
 ## How to run
 
 All the python files to run the framework are locate in [PhysicsTools/NanoMET/test/](PhysicsTools/NanoMET/test/). Then, use cmsRun to the files described below. For 2018 MC in 102X (NANOAODv7):

--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ cd PhysicsTools/NanoMET/test
 ```
 
 ### Add the DeepMET producer to Nano
-Add the DeepMET producer and Nano production chain by
+Add the DeepMET producer and Nano production chain:
 ```
 cd $CMSSW_BASE/src
 git cms-merge-topic yongbinfeng:NanoDeepMETIntegration_102X
 ```
-Update the `cmsswdata` to update the `RecoMET` directory by
+Update the `cmsswdata` to update the RecoMET METPUSubtraction data directory:
 ```
 patch $CMSSW_BASE/config/toolbox/slc7_amd64_gcc700/tools/selected/cmsswdata.xml < PhysicsTools/NanoMET/cmsswdata.patch
 ```
-Compile and go to the test directory
+Compile (this might take some time) and then go to the test directory:
 ```
 scram b -j 10
 cd PhysicsTools/NanoMET/test

--- a/cmsswdata.patch
+++ b/cmsswdata.patch
@@ -1,0 +1,8 @@
+42c42
+<       <flags CMSSW_DATA_PACKAGE="RecoMET/METPUSubtraction=V01-00-03"/>
+---
+>       <flags CMSSW_DATA_PACKAGE="RecoMET/METPUSubtraction=V01-01-00"/>
+94c94
+<     <runtime name="CMSSW_SEARCH_PATH" default="/cvmfs/cms.cern.ch/slc7_amd64_gcc700/cms/data-RecoMET-METPUSubtraction/V01-00-03" type="path"/>
+---
+>     <runtime name="CMSSW_SEARCH_PATH" default="/cvmfs/cms.cern.ch/slc7_amd64_gcc700/cms/data-RecoMET-METPUSubtraction/V01-01-00" type="path"/>


### PR DESCRIPTION
update the `README.md` to include the recipes to produce DeepMET in Nano for comparison. The `cmsswdata.xml` file also needs to be updated in 102x to point to the correct RecoMET METPUSubtraction data directory.

Four more DeepMET related variables will be added to the output: `DeepMETResponseTune_pt`, `DeepMETResponseTune_phi`, `DeepMETResolutionTune_pt`, and `DeepMETResolutionTune_phi`.

Tested locally and it worked fine.